### PR TITLE
Fixed style (background-color) of tippy-box

### DIFF
--- a/src/tippy-theme.css
+++ b/src/tippy-theme.css
@@ -1,36 +1,36 @@
 /* Tippy theme to use styling from Home Assistant theme */
 .tippy-box[data-theme~=homeassistant] {
-	color:var(--primary-text-color);
+	color: var(--primary-text-color);
 	box-shadow: var(
           --ha-card-box-shadow,
           0 2px 2px 0 rgba(0, 0, 0, 0.14),
           0 1px 5px 0 rgba(0, 0, 0, 0.12),
           0 3px 1px -2px rgba(0, 0, 0, 0.2)
         );
-	background-color:var(--paper-card-background-color);
-	z-index: 1000!important;
+	background-color: var(--ha-card-background, var(--card-background-color, var(--paper-card-background-color, white)));
+	z-index: 1000 !important;
 }
 
 .tippy-box[data-theme~=homeassistant][data-placement^=top]>.tippy-arrow:before {
-	border-top-color:var(--paper-card-background-color)
+	border-top-color: var(--ha-card-background, var(--card-background-color, var(--paper-card-background-color, white)));
 }
 
 .tippy-box[data-theme~=homeassistant][data-placement^=bottom]>.tippy-arrow:before {
-	border-bottom-color:var(--paper-card-background-color)
+	border-bottom-color: var(--ha-card-background, var(--card-background-color, var(--paper-card-background-color, white)));
 }
 
 .tippy-box[data-theme~=homeassistant][data-placement^=left]>.tippy-arrow:before {
-	border-left-color:var(--paper-card-background-color)
+	border-left-color: var(--ha-card-background, var(--card-background-color, var(--paper-card-background-color, white)));
 }
 
 .tippy-box[data-theme~=homeassistant][data-placement^=right]>.tippy-arrow:before {
-	border-right-color:var(--paper-card-background-color)
+	border-right-color: var(--ha-card-background, var(--card-background-color, var(--paper-card-background-color, white)));
 }
 
 .tippy-box[data-theme~=homeassistant]>.tippy-backdrop {
-	background-color:var(--paper-card-background-color)
+	background-color: var(--ha-card-background, var(--card-background-color, var(--paper-card-background-color, white)));
 }
 
 .tippy-box[data-theme~=homeassistant]>.tippy-svg-arrow {
-	fill:var(--paper-card-background-color)
+	fill: var(--ha-card-background, var(--card-background-color, var(--paper-card-background-color, white)));
 }


### PR DESCRIPTION
In my installation of home assistant there is no css-variable called `--paper-card-background-color` so I changed it to `var(--ha-card-background, var(--card-background-color, var(--paper-card-background-color, white)));`
Also there is now a default.